### PR TITLE
Replace XML character codes with real character for render

### DIFF
--- a/DocFx.Plugins.Kroki/KrokiPayload.cs
+++ b/DocFx.Plugins.Kroki/KrokiPayload.cs
@@ -24,7 +24,7 @@ namespace DocFx.Plugins.Kroki
 
     public KrokiPayload(string source, DiagramType diagramType, OutputFormat outputFormat)
     {
-      DiagramSource = source;
+      DiagramSource = System.Net.WebUtility.HtmlDecode(source);
       DiagramType = diagramType.ToString().ToLower();
       OutputFormat = outputFormat.ToString().ToLower();
     }

--- a/DocFx.Plugins.Kroki/Renderers/KrokiRenderer.cs
+++ b/DocFx.Plugins.Kroki/Renderers/KrokiRenderer.cs
@@ -28,8 +28,17 @@ namespace DocFx.Plugins.Kroki
     {
       var formatter = GetFormatter(_settings.OutputFormat, renderer.Options, DiagramType);
       var client = new KrokiClient(_settings.ServiceUrl);
-      var byteData = client.GetDiagram(new KrokiPayload(token.Code, DiagramType, _settings.OutputFormat)).Result;
+      var code = CodeCleanup(token.Code);
+      var byteData = client.GetDiagram(new KrokiPayload(code, DiagramType, _settings.OutputFormat)).Result;
       return formatter.FormatDiagramData(byteData);
+    }
+
+    private static string CodeCleanup(string raw)
+    {
+      // Markdown in source /// comments are preprocessed to escape XML reserved characters.
+      return raw.Replace("&amp;", "&")
+               .Replace("&lt;", "<")
+               .Replace("&gt;", ">");
     }
 
     private KrokiFormatter GetFormatter(OutputFormat outputFormat, Options options, DiagramType diagramType)

--- a/DocFx.Plugins.Kroki/Renderers/KrokiRenderer.cs
+++ b/DocFx.Plugins.Kroki/Renderers/KrokiRenderer.cs
@@ -28,17 +28,9 @@ namespace DocFx.Plugins.Kroki
     {
       var formatter = GetFormatter(_settings.OutputFormat, renderer.Options, DiagramType);
       var client = new KrokiClient(_settings.ServiceUrl);
-      var code = CodeCleanup(token.Code);
+      var code = System.Net.WebUtility.HtmlDecode(token.Code);
       var byteData = client.GetDiagram(new KrokiPayload(code, DiagramType, _settings.OutputFormat)).Result;
       return formatter.FormatDiagramData(byteData);
-    }
-
-    private static string CodeCleanup(string raw)
-    {
-      // Markdown in source /// comments are preprocessed to escape XML reserved characters.
-      return raw.Replace("&amp;", "&")
-               .Replace("&lt;", "<")
-               .Replace("&gt;", ">");
     }
 
     private KrokiFormatter GetFormatter(OutputFormat outputFormat, Options options, DiagramType diagramType)

--- a/DocFx.Plugins.Kroki/Renderers/KrokiRenderer.cs
+++ b/DocFx.Plugins.Kroki/Renderers/KrokiRenderer.cs
@@ -28,8 +28,7 @@ namespace DocFx.Plugins.Kroki
     {
       var formatter = GetFormatter(_settings.OutputFormat, renderer.Options, DiagramType);
       var client = new KrokiClient(_settings.ServiceUrl);
-      var code = System.Net.WebUtility.HtmlDecode(token.Code);
-      var byteData = client.GetDiagram(new KrokiPayload(code, DiagramType, _settings.OutputFormat)).Result;
+      var byteData = client.GetDiagram(new KrokiPayload(token.Code, DiagramType, _settings.OutputFormat)).Result;
       return formatter.FormatDiagramData(byteData);
     }
 


### PR DESCRIPTION
Diagrams as code can be included in XML /// comments, however certain characters are preprocessed and therefore aren't compiled into diagrams correctly.